### PR TITLE
HTTPS support for calling 3scale API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 *.iml
 .idea
 
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>threescale-api</artifactId>
     <name>3scale Java API</name>
     <url>http://http://www.3scale.net/</url>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
     <description>This API is used to encapsulate the communication with the 3scale backend server for validating and
         reporting transactions between the user and the provider of a service
     </description>

--- a/src/main/java/threescale/v3/api/impl/ServiceApiDriver.java
+++ b/src/main/java/threescale/v3/api/impl/ServiceApiDriver.java
@@ -11,6 +11,7 @@ public class ServiceApiDriver implements ServiceApi {
 
     private String provider_key = null;
     private String host = DEFAULT_HOST;
+    private boolean useHttps = false;
     private String redirect_url = "http://localhost:8080/oauth/oauth_redirect";
 
     private ServerAccessor server = null;
@@ -24,10 +25,23 @@ public class ServiceApiDriver implements ServiceApi {
         this.provider_key = provider_key;
         this.server = new ServerAccessorDriver();
     }
+    
+    public ServiceApiDriver(String provider_key, boolean useHttps) {
+        this.provider_key = provider_key;
+        this.useHttps = useHttps;
+        this.server = new ServerAccessorDriver();
+    }
 
     public ServiceApiDriver(String provider_key, String host) {
         this.provider_key = provider_key;
         this.host = host;
+        this.server = new ServerAccessorDriver();
+    }
+    
+    public ServiceApiDriver(String provider_key, String host, boolean useHttps) {
+        this.provider_key = provider_key;
+        this.host = host;
+        this.useHttps = useHttps;
         this.server = new ServerAccessorDriver();
     }
 
@@ -112,7 +126,8 @@ public class ServiceApiDriver implements ServiceApi {
     }
 
     private String getFullHostUrl() {
-        return "http://" + getHost();
+        
+        return useHttps ? "https://" + getHost() : "http://" + getHost();
     }
 
 


### PR DESCRIPTION
Added support for HTTPS. One can specify in the constructor ServiceApiDriver whether it should use or not HTTPS:
1. public ServiceApiDriver(String provider_key, boolean useHttps)
2. public ServiceApiDriver(String provider_key, String host, boolean useHttps)
