### PR TITLE
Added support for service tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install
 =======
 
 This is a [Maven](http://maven.apache.org/) project, download it and install it as follows
-- add a dependency to this artifact inside your pom.xml by opening the pom.xml insdie the 3scale artifact and retrieving the groupId, artifactid and version from lines 5,6 and 9 of 3scale's pom.
+- add a dependency to this artifact inside your pom.xml by opening the pom.xml inside the 3scale artifact and retrieving the groupId, artifactid and version from lines 5,6 and 9 of 3scale's pom.
 - install the artifact to your repository as described here:
 http://maven.apache.org/guides/mini/guide-3rd-party-jars-local.html
 
@@ -40,12 +40,14 @@ import threescale.v3.api.impl.*;
 //  ... somewhere inside your code
 
 // Create the API object
-ServiceApi serviceApi = new ServiceApiDriver("your provider_key");
+ServiceApi serviceApi = ServiceApiDriver.createApi();
 
 ParameterMap params = new ParameterMap();      // the parameters of your call
 params.add("app_id", "your_app_id");           // Add app_id of your application for authorization
 params.add("app_key", "your_app_key");         // Add app_key of your application for authorization
-params.add("service_id", "app_id_service_id"); // Add the service id of your application
+
+String serviceToken = ...;                     // Your 3scale service token
+String serviceId = ...;                        // The service id of your application
 
 ParameterMap usage = new ParameterMap(); // Add a metric to the call
 usage.add("hits", "1");
@@ -54,7 +56,7 @@ params.add("usage", usage);              // metrics belong inside the usage para
 AuthorizeResponse response = null;
 // the 'preferred way' of calling the backend: authrep
 try {
-  response = serviceApi.authrep(params);
+  response = serviceApi.authrep(serviceToken, serviceId, params);
   System.out.println("AuthRep on App Id Success: " + response.success());
   if (response.success() == true) {
     // your api access got authorized and the  traffic added to 3scale backend
@@ -82,11 +84,13 @@ import threescale.v3.api.impl.*;
 //  ... somewhere inside your code
 
 // Create the API object
-ServiceApi serviceApi = new ServiceApiDriver("your provider_key");
+ServiceApi serviceApi = ServiceApiDriver.createApi();
 
 ParameterMap params = new ParameterMap();              // the parameters of your call
 params.add("user_key", "your_user_key");               // Add the user key of your application for authorization
-params.add("service_id", "your_user_key_service_id");  // Add the service id of your application
+
+String serviceToken = ...;                             // Your 3scale service token
+String serviceId = ...;                                // The service id for your user key
 
 ParameterMap usage = new ParameterMap(); // Add a metric to the call
 usage.add("hits", "1");
@@ -95,7 +99,7 @@ params.add("usage", usage);              // metrics belong inside the usage para
 AuthorizeResponse response = null;
 // the 'preferred way' of calling the backend: authrep
 try {
-  response = serviceApi.authrep(params);
+  response = serviceApi.authrep(serviceToken, serviceId, params);
   System.out.println("AuthRep on User Key Success: " + response.success());
   if (response.success() == true) {
     // your api access got authorized and the  traffic added to 3scale backend
@@ -123,11 +127,13 @@ import threescale.v3.api.impl.*;
 //  ... somewhere inside your code
 
 // Create the API object
-ServiceApi serviceApi = new ServiceApiDriver("your provider_key");
+ServiceApi serviceApi = ServiceApiDriver.createApi();
 
 ParameterMap params = new ParameterMap();          // the parameters of your call
 params.add("app_id",     "your_oauth_app_id");     // Add the app_id of your application for authorization
-params.add("service_id", "your_oauth_service_id"); // Add the service id of your application
+
+String serviceToken = ...;                         // Your 3scale service token
+String serviceId = ...;                            // The service id of your application
 
 ParameterMap usage = new ParameterMap(); // Add a metric to the call
 usage.add("hits", "1");
@@ -135,7 +141,7 @@ params.add("usage", usage);              // metrics belong inside the usage para
 
 // for OAuth only the '2 steps way' (authorize + report) is available
 try {
-    AuthorizeResponse response = serviceApi.oauth_authorize(params);         // Perform OAuth authorize
+    AuthorizeResponse response = serviceApi.oauth_authorize(serviceToken, serviceId, params);         // Perform OAuth authorize
     System.out.println("Authorize on OAuth Success: " + response.success());
     if (response.success() == true) {
 

--- a/src/main/java/threescale/v3/api/ParameterMap.java
+++ b/src/main/java/threescale/v3/api/ParameterMap.java
@@ -1,5 +1,6 @@
 package threescale.v3.api;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Set;
@@ -101,6 +102,9 @@ public class ParameterMap {
         if (clazz == ParameterMap.class) {
             return ParameterMapType.MAP;
         }
+        if (clazz == Long.class) {
+            return ParameterMapType.LONG;
+        }
         throw new RuntimeException("Unknown object in parameters");
     }
 
@@ -111,7 +115,17 @@ public class ParameterMap {
      * @return
      */
     public String getStringValue(String key) {
+        switch (getType(key)) {
+        case ARRAY:
+            return Arrays.toString((ParameterMap[]) data.get(key));
+        case LONG:
+            return Long.toString((Long) data.get(key));
+        case MAP:
+            return ((ParameterMap) data.get(key)).toString(); //
+        case STRING:
         return (String) data.get(key);
+        }
+        return null;
     }
 
     /**
@@ -132,6 +146,12 @@ public class ParameterMap {
      */
     public ParameterMap[] getArrayValue(String key) {
         return (ParameterMap[]) data.get(key);
+    }
+    public long getLongValue(String key) {
+        return (Long) data.get(key);
+    }
+    public void setLongValue(String key, long value) {
+        data.put(key, value);
     }
 
     /**

--- a/src/main/java/threescale/v3/api/ParameterMapType.java
+++ b/src/main/java/threescale/v3/api/ParameterMapType.java
@@ -4,5 +4,5 @@ package threescale.v3.api;
  * Enum for the type that can be stored in a ParameterMap.
  */
 public enum ParameterMapType {
-    STRING, MAP, ARRAY;
+    STRING, MAP, ARRAY, LONG;
 }

--- a/src/main/java/threescale/v3/api/ServiceApi.java
+++ b/src/main/java/threescale/v3/api/ServiceApi.java
@@ -14,6 +14,8 @@ public interface ServiceApi {
      * @throws ServerError Thrown if there is an error communicating with the 3Scale server
      */
     public AuthorizeResponse authrep(ParameterMap metrics) throws ServerError;
+	public AuthorizeResponse authrep(String serviceToken, String serviceId, ParameterMap metrics) 
+			throws ServerError;
 
     /**
      * Performs an Authorize
@@ -23,6 +25,8 @@ public interface ServiceApi {
      * @throws ServerError Thrown if there is an error communicating with the 3Scale server
      */
     public AuthorizeResponse authorize(ParameterMap parameters) throws ServerError;
+    public AuthorizeResponse authorize(String serviceToken, String serviceId, ParameterMap parameters) 
+    		throws ServerError;
 
     /**
      * Perform an Authorize using OAuth.
@@ -32,16 +36,21 @@ public interface ServiceApi {
      * @throws ServerError Thrown if there is an error communicating with the 3Scale server
      */
     public AuthorizeResponse oauth_authorize(ParameterMap params) throws ServerError;
+    public AuthorizeResponse oauth_authorize(String serviceToken, String serviceId, ParameterMap params) 
+    		throws ServerError;
 
     /**
-     * Report a set of metrics.
+     * Report a set of metrics.  Note: report differs from the rest of these methods in that a serviceId is 
+     * an argument.  The reason for this is that it does not accept a root level ParameterMap argument, which is
+     * normally how the serviceId would be passed.  Instead, the root level ParameterMap is created by the 
+     * implementation, and so the serviceId cannot be included in it. 
      *
-     * @param service_id
      * @param transactions The metrics to be reported
      * @return Information about the success/failure of the operation
      * @throws ServerError Thrown if there is an error communicating with the 3Scale server
      */
-    public ReportResponse report(String service_id, ParameterMap... transactions) throws ServerError;
+    public ReportResponse report(String serviceId, ParameterMap... transactions) throws ServerError;
+    public ReportResponse report(String serviceToken, String serviceId, ParameterMap... transactions) throws ServerError;
 
     /**
      * Get the URL of the 3scale server

--- a/src/main/java/threescale/v3/api/impl/ParameterEncoder.java
+++ b/src/main/java/threescale/v3/api/impl/ParameterEncoder.java
@@ -29,11 +29,16 @@ public class ParameterEncoder {
                 case ARRAY:
                     result.append(emitNormalArray(mapKey, params.getArrayValue(mapKey)));
                     break;
+                case LONG:
+                    result.append(emitNormalValue(mapKey, Long.toString(params.getLongValue(mapKey))));
+                    break;
+                default:
+                    break;
             }
             index++;
         }
 
-        return substitueCharacters(result.toString());
+        return substituteCharacters(result.toString());
     }
 
     private String emitNormalArray(String mapKey, ParameterMap[] mapValue) {
@@ -71,6 +76,10 @@ public class ParameterEncoder {
                 case ARRAY:
                     // TODO does ARRAY need to be handled?
                     break;
+                case LONG:
+                    break;
+                default:
+                    break;
             }
         }
         return b.toString();
@@ -90,6 +99,9 @@ public class ParameterEncoder {
         for (String key : mapValue.getKeys()) {
             if (index != 0) b.append("&");
             switch (mapValue.getType(key)) {
+                case LONG:
+                    b.append(emitMapValue(mapKey, key, Long.toString(mapValue.getLongValue(key))));
+                    break;      
                 case STRING:
                     b.append(emitMapValue(mapKey, key, mapValue.getStringValue(key)));
                     break;
@@ -107,7 +119,7 @@ public class ParameterEncoder {
 
     private String emitMapValue(String mapKey, String key, String stringValue) {
         StringBuilder b = new StringBuilder();
-        b.append("[").append(mapKey).append("][").append(key).append("]=").append(stringValue);
+        b.append(mapKey).append("[").append(key).append("]=").append(stringValue);
         return b.toString();
     }
 
@@ -117,7 +129,7 @@ public class ParameterEncoder {
         return b.toString();
     }
 
-    private String substitueCharacters(String input) {
+    private String substituteCharacters(String input) {
         return input.replace(" ", "%20").replace("[", "%5B").replace("]", "%5D").replace("#", "%23").replace(":", "%3A");
     }
 }

--- a/src/main/java/threescale/v3/api/impl/ServiceApiDriver.java
+++ b/src/main/java/threescale/v3/api/impl/ServiceApiDriver.java
@@ -8,6 +8,25 @@ import threescale.v3.api.*;
  * @see ServiceApi
  */
 public class ServiceApiDriver implements ServiceApi {
+	
+	/**
+	 * Creates a Service Api with default settings.  This will communicate with the 3scale
+	 * platform SaaS default server.
+	 */
+	public static ServiceApi createApi() {
+		return ServiceApiDriver.createApi(ServiceApi.DEFAULT_HOST, 443, true);
+	}
+	
+	/**
+	 * Creates a Service Api for the given host.  Use this method when connecting to an on-premise
+	 * instance of the 3scale platform.
+	 */
+	public static ServiceApi createApi(String host, int port, boolean useHttps) {
+		ServiceApiDriver driver = new ServiceApiDriver();
+		driver.host = host + ":" + port;
+		driver.useHttps = useHttps;
+		return driver;
+	}
 
     private String provider_key = null;
     private String host = DEFAULT_HOST;
@@ -20,23 +39,39 @@ public class ServiceApiDriver implements ServiceApi {
         this.server = new ServerAccessorDriver();
     }
 
+    /**
+     * @deprecated Instead of using a provider_key, use service tokens.  See static constructor methods: createApi().
+     */
+    @Deprecated
     public ServiceApiDriver(String provider_key) {
         this.provider_key = provider_key;
         this.server = new ServerAccessorDriver();
     }
     
+    /**
+     * @deprecated Instead of using a provider_key, use service tokens.  See static constructor methods: createApi().
+     */
+    @Deprecated
     public ServiceApiDriver(String provider_key, boolean useHttps) {
         this.provider_key = provider_key;
         this.useHttps = useHttps;
         this.server = new ServerAccessorDriver();
     }
 
+    /**
+     * @deprecated Instead of using a provider_key, use service tokens.  See static constructor methods: createApi().
+     */
+    @Deprecated
     public ServiceApiDriver(String provider_key, String host) {
         this.provider_key = provider_key;
         this.host = host;
         this.server = new ServerAccessorDriver();
     }
     
+    /**
+     * @deprecated Instead of using a provider_key, use service tokens.  See static constructor methods: createApi().
+     */
+    @Deprecated
     public ServiceApiDriver(String provider_key, String host, boolean useHttps) {
         this.provider_key = provider_key;
         this.host = host;
@@ -44,8 +79,13 @@ public class ServiceApiDriver implements ServiceApi {
         this.server = new ServerAccessorDriver();
     }
     
+    /* (non-Javadoc)
+     * @see threescale.v3.api.ServiceApi#authrep(threescale.v3.api.ParameterMap)
+     */
     public AuthorizeResponse authrep(ParameterMap metrics) throws ServerError {
-        metrics.add("provider_key", provider_key);
+    	if (this.provider_key != null) {
+            metrics.add("provider_key", provider_key);
+    	}
 
         ParameterMap usage = metrics.getMapValue("usage");
 
@@ -67,15 +107,37 @@ public class ServiceApiDriver implements ServiceApi {
         }
         return convertXmlToAuthorizeResponse(response);
     }
-
-    public ReportResponse report(String service_id, ParameterMap... transactions) throws ServerError {
+    
+    /* (non-Javadoc)
+     * @see threescale.v3.api.ServiceApi#authrep(java.lang.String, java.lang.String, threescale.v3.api.ParameterMap)
+     */
+    public AuthorizeResponse authrep(String serviceToken, String serviceId, ParameterMap metrics) throws ServerError {
+    	if (serviceToken != null) {
+    		metrics.add("service_token", serviceToken);
+    	}
+    	if (serviceId != null) {
+    		metrics.add("service_id", serviceId);
+    	}
+    	return authrep(metrics);
+    }
+    
+    /* (non-Javadoc)
+     * @see threescale.v3.api.ServiceApi#report(java.lang.String, java.lang.String, threescale.v3.api.ParameterMap[])
+     */
+    public ReportResponse report(String serviceToken, String serviceId, ParameterMap... transactions)
+    		throws ServerError {
         if (transactions == null || transactions.length == 0)
             throw new IllegalArgumentException("No transactions provided");
 
         ParameterMap params = new ParameterMap();
-        params.add("provider_key", provider_key);
-        if (service_id != null) {
-            params.add("service_id", service_id);
+        if (this.provider_key != null) {
+            params.add("provider_key", provider_key);
+        }
+        if (serviceToken != null) {
+            params.add("service_token", serviceToken);
+        }
+        if (serviceId != null) {
+            params.add("service_id", serviceId);
         }
         params.add("transactions", transactions);
 
@@ -85,9 +147,19 @@ public class ServiceApiDriver implements ServiceApi {
         }
         return new ReportResponse(response);
     }
+    
+    @Override
+    public ReportResponse report(String serviceId, ParameterMap... transactions) throws ServerError {
+    	return this.report(null, serviceId, transactions);
+    }
 
+    /* (non-Javadoc)
+     * @see threescale.v3.api.ServiceApi#authorize(threescale.v3.api.ParameterMap)
+     */
     public AuthorizeResponse authorize(ParameterMap parameters) throws ServerError {
-        parameters.add("provider_key", provider_key);
+    	if (this.provider_key != null) {
+            parameters.add("provider_key", provider_key);
+    	}
         String urlParams = encodeAsString(parameters);
 
         final String s = getFullHostUrl() + "/transactions/authorize.xml?" + urlParams;
@@ -97,13 +169,30 @@ public class ServiceApiDriver implements ServiceApi {
         }
         return convertXmlToAuthorizeResponse(response);
     }
+    
+    @Override
+    public AuthorizeResponse authorize(String serviceToken, String serviceId, ParameterMap parameters)
+    		throws ServerError {
+    	if (serviceToken != null) {
+    		parameters.add("service_token", serviceToken);
+    	}
+    	if (serviceId != null) {
+    		parameters.add("service_id", serviceId);
+    	}
+    	return authorize(parameters);
+    }
 
     public String getHost() {
         return host;
     }
 
+    /* (non-Javadoc)
+     * @see threescale.v3.api.ServiceApi#oauth_authorize(threescale.v3.api.ParameterMap)
+     */
     public AuthorizeResponse oauth_authorize(ParameterMap params) throws ServerError {
-        params.add("provider_key", provider_key);
+    	if (this.provider_key != null) {
+            params.add("provider_key", provider_key);
+    	}
 
         String urlParams = encodeAsString(params);
 
@@ -115,6 +204,20 @@ public class ServiceApiDriver implements ServiceApi {
             throw new ServerError(response.getBody());
         }
         return convertXmlToAuthorizeResponse(response);
+    }
+    
+    /* (non-Javadoc)
+     * @see threescale.v3.api.ServiceApi#oauth_authorize(java.lang.String, java.lang.String, threescale.v3.api.ParameterMap)
+     */
+    public AuthorizeResponse oauth_authorize(String serviceToken, String serviceId, ParameterMap params)
+    		throws ServerError {
+    	if (serviceToken != null) {
+    		params.add("service_token", serviceToken);
+    	}
+    	if (serviceId != null) {
+    		params.add("service_id", serviceId);
+    	}
+    	return oauth_authorize(params);
     }
 
     private String getFullHostUrl() {

--- a/src/test/java/threescale/v3/api/ServiceApiDriverTest.java
+++ b/src/test/java/threescale/v3/api/ServiceApiDriverTest.java
@@ -62,7 +62,7 @@ public class ServiceApiDriverTest {
 
     @Test
     public void test_authrep_usage_is_encoded() throws ServerError {
-    	assertAuthrepUrlWithParams("%5Busage%5D%5Bmethod%5D=666");
+    	assertAuthrepUrlWithParams("usage%5Bmethod%5D=666");
 
         ParameterMap params = new ParameterMap();
         ParameterMap usage = new ParameterMap();
@@ -75,7 +75,7 @@ public class ServiceApiDriverTest {
     @Test
     public void test_authrep_usage_values_are_encoded() throws ServerError {
 
-        assertAuthrepUrlWithParams("%5Busage%5D%5Bhits%5D=%230");
+        assertAuthrepUrlWithParams("usage%5Bhits%5D=%230");
 
         ParameterMap params = new ParameterMap();
         ParameterMap usage = new ParameterMap();
@@ -88,7 +88,7 @@ public class ServiceApiDriverTest {
     @Test
     public void test_authrep_usage_defaults_to_hits_1() throws ServerError {
 
-        assertAuthrepUrlWithParams("%5Busage%5D%5Bhits%5D=1&app_id=appid");
+        assertAuthrepUrlWithParams("usage%5Bhits%5D=1&app_id=appid");
 
         ParameterMap params = new ParameterMap();
         params.add("app_id", "appid");
@@ -98,7 +98,7 @@ public class ServiceApiDriverTest {
 
     @Test
     public void test_authrep_supports_app_id_app_key_auth_mode() throws ServerError {
-        assertAuthrepUrlWithParams("%5Busage%5D%5Bhits%5D=1&app_key=appkey&app_id=appid");
+        assertAuthrepUrlWithParams("usage%5Bhits%5D=1&app_key=appkey&app_id=appid");
 
         ParameterMap params = new ParameterMap();
         params.add("app_id", "appid");
@@ -114,7 +114,7 @@ public class ServiceApiDriverTest {
                 "</status>";
 
         context.checking(new UrlWithParamsExpectations() {{
-            oneOf(htmlServer).get(withUrl("http://" + host + "/transactions/authrep.xml?provider_key=1234abcd&%5Busage%5D%5Bhits%5D=1&app_key=toosecret&app_id=foo"));
+            oneOf(htmlServer).get(withUrl("http://" + host + "/transactions/authrep.xml?provider_key=1234abcd&usage%5Bhits%5D=1&app_key=toosecret&app_id=foo"));
             will(returnValue(new HttpResponse(200, body)));
         }});
 

--- a/src/test/java/threescale/v3/api/impl/ParameterEncoderTest.java
+++ b/src/test/java/threescale/v3/api/impl/ParameterEncoderTest.java
@@ -52,7 +52,7 @@ public class ParameterEncoderTest {
         usage.add("hits", "111");
         param.add("usage", usage);
 
-        assertEquals("provider_key=123abc&app_id=3456aaa&%5Busage%5D%5Bhits%5D=111", encoder.encode(param));
+        assertEquals("provider_key=123abc&app_id=3456aaa&usage%5Bhits%5D=111", encoder.encode(param));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class ParameterEncoderTest {
 
 
         assertEquals(
-                "provider_key=123abc&app_id=3456aaa&%5Busage%5D%5Bhits%5D=111&%5Busage%5D%5Btimestamp%5D=2010-04-27%2015%3A00%3A00%20+0000",
+                "provider_key=123abc&app_id=3456aaa&usage%5Bhits%5D=111&usage%5Btimestamp%5D=2010-04-27%2015%3A00%3A00%20+0000",
                 encoder.encode(param));
     }
 


### PR DESCRIPTION
Technically, only `report` was missing the ability to use service tokens.  The reason is that for all methods except for `report`, a generic ParameterMap is the argument passed to the method.  Simply adding the service_token to that map would be sufficient for auth and authrep.  However, because report doesn't accept the root ParameterMap as an argument, the service token (and also service id) must be passed as arguments.

This behavior has been preserved.  In addition, new variants of all four API methods (authorize, authrep, oauth_authorize, report) have been added that explicitly accept the serviceId and serviceToken.

In addition, I have deprecated all of the ServiceApiDriver constructors which accept a `provider_key`.  Existing code will continue to work, but developers will receive deprecation warnings.  To replace these constructors (and to avoid confusion), I have added two new static constructor methods:

```java
	public static ServiceApi createApi();
	public static ServiceApi createApi(String host, int port, boolean useHttps);
```

The former will default to the 3scale SaaS platform, while the latter obviously can be used when running on-prem.

Documentation for #31 should probably be updated to leverage the above methods rather than the constructors.  I have updated the repository's readme appropriately.

